### PR TITLE
Simplify `ansible_python_interpreter`

### DIFF
--- a/ansible/archivewebsible
+++ b/ansible/archivewebsible
@@ -59,7 +59,6 @@ ensure_oc4_login () {
 ensure_suitcase
 
 declare -a ansible_args
-ansible_args=(-e "archivewebsible_suitcase_dir=$PWD/ansible-deps-cache")
 inventory_mode="test"
 while [ "$#" -gt 0 ]; do
   case "$1" in

--- a/ansible/inventory/prod.yml
+++ b/ansible/inventory/prod.yml
@@ -6,7 +6,7 @@ all:
       vars:
         ansible_connection: local
         openshift_namespace: 'svc0041p-web-archiving'
-        ansible_python_interpreter: '{{archivewebsible_suitcase_dir}}/bin/python3'
+        ansible_python_interpreter: '{{ ansible_playbook_python }}'
         routes_availability: public
         pv_name: svc0041p-web-archiving-pv
         pv_size: 20Gi


### PR DESCRIPTION
`archivewebsible_suitcase_dir` not needed for `ansible_python_interpreter`.

Close: #242